### PR TITLE
Fix: replace rm_stub() with base R in fastverse_conflicts example

### DIFF
--- a/R/conflicts.R
+++ b/R/conflicts.R
@@ -54,7 +54,7 @@ confirm_conflict <- function(packages, name) { # packages <- conflicts[[3]]; nam
 #' fastverse_conflicts()
 #' 
 #' # Check conflicts among all attached packages
-#' fastverse_conflicts(rm_stub(search()[-1], "package:"))
+#' fastverse_conflicts(sub("package:", "", search()[-1], fixed = TRUE))
 fastverse_conflicts <- function(pkg = fastverse_packages()) {
   envs <- grep("^package:", search(), value = TRUE)
   names(envs) <- envs

--- a/man/fastverse_conflicts.Rd
+++ b/man/fastverse_conflicts.Rd
@@ -31,7 +31,7 @@ There are 3 internal conflicts in the core \emph{fastverse} which are not displa
 fastverse_conflicts()
 
 # Check conflicts among all attached packages
-fastverse_conflicts(rm_stub(search()[-1], "package:"))
+fastverse_conflicts(sub("package:", "", search()[-1], fixed = TRUE))
 }
 \seealso{
 \code{\link{fastverse}}


### PR DESCRIPTION
Fixes #159

Replaces `rm_stub()` (removed in collapse 2.0+) with the base R equivalent `sub("package:", "", ..., fixed = TRUE)` in the `fastverse_conflicts` example. This fixes R CMD check failures on Ubuntu where newer package versions are installed.

Generated with [Claude Code](https://claude.ai/code)